### PR TITLE
Add call to PySys_SetArgvEx() in CDgnAppSupport::Register()

### DIFF
--- a/NatlinkSource/COM/appsupp.cpp
+++ b/NatlinkSource/COM/appsupp.cpp
@@ -53,6 +53,8 @@ STDMETHODIMP CDgnAppSupport::Register( IServiceProvider * pIDgnSite )
 	// load and initialize the Python system
 	Py_Initialize();
 
+	// Set sys.argv so it exists as [''].
+	PySys_SetArgvEx(1, NULL, 0);
 
 	// load the natlink module into Python and return a pointer to the
 	// shared CDragonCode object


### PR DESCRIPTION
Fixes #3.

This change sets `sys.argv` to `['']` after the Python interpreter is started. Previously, using `sys.argv` in Python would raise `AttributeErrors`.

I've used `1` for `argc` and `NULL` for `argv` because command-line arguments make no sense in `CDgnAppSupport::Register()`.

I am not currently able to compile Natlink because I don't have Visual Studio installed. However, I have tested the change in a simple C++ embedded Python program with Python 2.7 and 3.7. Still, try out the change before merging.