### PR TITLE
initial exercises Quintijn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,3 @@ MacroSystem/*_vcl.py
 
 # Visual Studio
 .vs
-/NatlinkModule/config_in_loader_proposal_qh.py

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ MacroSystem/*_vcl.py
 
 # Visual Studio
 .vs
+/NatlinkModule/config_in_loader_proposal_qh.py

--- a/InstallerSource/inno-code.iss
+++ b/InstallerSource/inno-code.iss
@@ -189,8 +189,8 @@ begin
   DragonVersion := 'XXX'; 
   if IsDragonRunning() then
   begin
-    MsgBox('Dragon is running, aborting. '
-    + 'Please close dragonbar.exe and/or natspeak.exe then try again.', mbError, MB_OK );
+    MsgBox('Dragon is running, this installer is aborting. '
+    + 'Please Exit Dragon (the DragonBar) and then try this installer again.', mbError, MB_OK );
     Result := False;
     exit;
   end;

--- a/NatlinkModule/InstallTest/_meet_natlink.py
+++ b/NatlinkModule/InstallTest/_meet_natlink.py
@@ -1,9 +1,12 @@
 import sys
 import sysconfig
+from pprint import pprint
 print("I'm _meet_natlink.py and I'm being loaded, too, on my own.")
-print("This is your Python configuration as per sysconfig")
-print("--------------------------------------------------")
+print("This is your Python configuration as per sysconfig:")
+print("---------------------------------------------------")
 sysconfig._main()
-print("This is your Python system path sys.path")
-print("----------------------------------------")
-print(sys.path)
+print("This is your Python system path sys.path:")
+print("-----------------------------------------")
+pprint(sys.path)
+print("End of _meet_natlink.py info.")
+print("-----------------------------")

--- a/NatlinkModule/config.py
+++ b/NatlinkModule/config.py
@@ -5,9 +5,11 @@ from collections import OrderedDict
 from enum import IntEnum
 from typing import List, Iterable, Dict
 
+import natlink
+
 NATLINK_INI = "natlink.ini"
-class NoGoodConfigFoundException(Exception):
-    """No good config file found"""
+class NoGoodConfigFoundException(natlink.NatError):
+    pass
 
 
 class LogLevel(IntEnum):

--- a/NatlinkModule/config.py
+++ b/NatlinkModule/config.py
@@ -5,11 +5,9 @@ from collections import OrderedDict
 from enum import IntEnum
 from typing import List, Iterable, Dict
 
-import natlink
-
 NATLINK_INI = "natlink.ini"
-class NoGoodConfigFoundException(natlink.NatError):
-    pass
+class NoGoodConfigFoundException(Exception):
+    """No good config file found"""
 
 
 class LogLevel(IntEnum):
@@ -96,3 +94,4 @@ class NatlinkConfig:
                 return cls.from_config_parser(config)
         # should not happen, because of InstallTest
         raise NoGoodConfigFoundException(f'No config file found, did you define your {NATLINK_INI}?')
+    

--- a/NatlinkModule/loader.py
+++ b/NatlinkModule/loader.py
@@ -1,10 +1,10 @@
-#pylint:disable=C0114, C0115, C0116, R1705, R0902, W0703
+#pylint:disable=C0114, C0115, C0116, R1705, R0902, W0703, E1101
 import importlib
 import importlib.machinery
 import importlib.util
 import logging
 import os
-import subprocess
+# import subprocess
 import sys
 import sysconfig
 import time
@@ -229,6 +229,67 @@ def config_locations() -> Iterable[str]:
     return ((getenv("NATLINK_INI") and [getenv("NATLINK_INI")]) or
             [expanduser(join(loc, NATLINK_INI)) for loc in possible_dirs])
   
+# def config_locations() -> Iterable[str]:
+#     r"""find possible config locations for NATLINK_INI
+#     
+#     1. name of config_file is defined as NATLINK_INI in config.py, but could be overridden by
+#     setting NATLINK_INI as environment variable.
+#         - if this variable is a valid filepath, take this
+#         - if this variable is a valid directory, take this directory / NATLINK_INI
+#     
+#     2.  the location of NATLINK_INI can also be configured by the
+#         env variable DICTATIONTOOLBOXHOME
+#         
+#         If so, below this (valid directory) there should be a directory ".natlink", and
+#         inside this directory there should be the file NATLINK_INI ("natlink.ini")
+#         
+#     3.  Otherwise, several directories are searched:
+#         "~" ("C:\Users\Username")
+#         "~/Documents"
+#         "~/.natlink"
+#         
+#     4.  As a last resort, the default directory for testing "C:\Program Files (x86)\Natlink\InstallTest" is taken.
+#         When you start Dragon with this default directory, it gives some useful information, but no grammars are loaded yet.
+#     
+#     """
+#     join, expanduser, getenv = os.path.join, os.path.expanduser, os.getenv
+#     
+#     # env variable NATLINK_INI can be a file or a directory:
+#     natlink_ini = getenv("NATLINK_INI")
+#     if natlink_ini and os.path.isfile(natlink_ini):
+#         # logger.info(f'take config_file from env variable NATLINK_INI: "{natlink_ini}"')
+#         return [natlink_ini]
+#     if natlink_ini and os.path.isdir(natlink_ini):
+#         natlink_ini_file = join(natlink_ini, NATLINK_INI)
+#         if os.path.isfile(natlink_ini_file):
+#             # logger.info(f'take config_file from directory of env variable NATLINK_INI: "{natlink_ini}"'
+#             #                  '\n\tSo config file is: "{natlink_ini_file}"')
+#             return [natlink_ini_file]
+#         # logger.warning(f'env variable NATLINK_INI points to directory: "{natlink_ini}", but does not have a valid file "natlink.ini"')
+#     # if natlink_ini:
+#     #     logger.warning(f'you defined env variable NATLINK_INI to "{natlink_ini}", but it'
+#     #                    '\n\tdoes not point to a valid directory with file "{NATLINK_INI}" or to a valid file')
+# 
+#     documents_dir = getenv('PERSONAL')
+#     possible_dirs = ['~/.natlink', join(documents_dir, ".natlink"),
+#                      '~/', documents_dir,
+#                      join(get_natlink_system_config_filename(), "InstallTest")]
+#     dictationtoolboxhome = getenv("DICTATIONTOOLBOXHOME")
+#     if dictationtoolboxhome and os.path.isdir(dictationtoolboxhome):
+#         natlink_config_dir = join(dictationtoolboxhome, '.natlink')
+#         if os.path.isdir(natlink_config_dir):
+#             # logger.info('add sub directory ".natlink" from env variable DICTATIONTOOLBOXHOME to'
+#                             # f'\n\tsearch for a valid config location: "%s"'% natlink_config_dir)
+#             possible_dirs.insert(0, natlink_config_dir)
+#         # else:
+#         #     logger.warning(f'env variable DICTATIONTOOLBOXHOME is set to "{dictationtoolboxhome}", but'
+#         #                         '\n\tno valid directory ".natlink" for the natlink config file is found')
+#     # elif dictationtoolboxhome:
+#     #     logger.warning(f'env variable DICTATIONTOOLBOXHOME is defined, but does not point to a '
+#     #                         f'\n\tvalid directory: "{dictationtoolboxhome}')
+# 
+#     return [expanduser(join(loc, NATLINK_INI)) for loc in possible_dirs]
+
 def run() -> None:
     logger = logging.getLogger('natlink')
 

--- a/NatlinkModule/loader.py
+++ b/NatlinkModule/loader.py
@@ -4,7 +4,6 @@ import importlib.machinery
 import importlib.util
 import logging
 import os
-# import subprocess
 import sys
 import sysconfig
 import time
@@ -224,71 +223,10 @@ def get_natlink_system_config_filename() -> str:
 
 def config_locations() -> Iterable[str]:
     join, expanduser, getenv = os.path.join, os.path.expanduser, os.getenv
-    possible_dirs = ['~/', '~/Documents', '~/.natlink',
+    possible_dirs = ['~/.natlink', '~/Documents/.natlink', '~/Documents','~/',
                      join(get_natlink_system_config_filename(), "InstallTest")]
-    return ((getenv("NATLINK_INI") and [getenv("NATLINK_INI")]) or
-            [expanduser(join(loc, NATLINK_INI)) for loc in possible_dirs])
-  
-# def config_locations() -> Iterable[str]:
-#     r"""find possible config locations for NATLINK_INI
-#     
-#     1. name of config_file is defined as NATLINK_INI in config.py, but could be overridden by
-#     setting NATLINK_INI as environment variable.
-#         - if this variable is a valid filepath, take this
-#         - if this variable is a valid directory, take this directory / NATLINK_INI
-#     
-#     2.  the location of NATLINK_INI can also be configured by the
-#         env variable DICTATIONTOOLBOXHOME
-#         
-#         If so, below this (valid directory) there should be a directory ".natlink", and
-#         inside this directory there should be the file NATLINK_INI ("natlink.ini")
-#         
-#     3.  Otherwise, several directories are searched:
-#         "~" ("C:\Users\Username")
-#         "~/Documents"
-#         "~/.natlink"
-#         
-#     4.  As a last resort, the default directory for testing "C:\Program Files (x86)\Natlink\InstallTest" is taken.
-#         When you start Dragon with this default directory, it gives some useful information, but no grammars are loaded yet.
-#     
-#     """
-#     join, expanduser, getenv = os.path.join, os.path.expanduser, os.getenv
-#     
-#     # env variable NATLINK_INI can be a file or a directory:
-#     natlink_ini = getenv("NATLINK_INI")
-#     if natlink_ini and os.path.isfile(natlink_ini):
-#         # logger.info(f'take config_file from env variable NATLINK_INI: "{natlink_ini}"')
-#         return [natlink_ini]
-#     if natlink_ini and os.path.isdir(natlink_ini):
-#         natlink_ini_file = join(natlink_ini, NATLINK_INI)
-#         if os.path.isfile(natlink_ini_file):
-#             # logger.info(f'take config_file from directory of env variable NATLINK_INI: "{natlink_ini}"'
-#             #                  '\n\tSo config file is: "{natlink_ini_file}"')
-#             return [natlink_ini_file]
-#         # logger.warning(f'env variable NATLINK_INI points to directory: "{natlink_ini}", but does not have a valid file "natlink.ini"')
-#     # if natlink_ini:
-#     #     logger.warning(f'you defined env variable NATLINK_INI to "{natlink_ini}", but it'
-#     #                    '\n\tdoes not point to a valid directory with file "{NATLINK_INI}" or to a valid file')
-# 
-#     documents_dir = getenv('PERSONAL')
-#     possible_dirs = ['~/.natlink', join(documents_dir, ".natlink"),
-#                      '~/', documents_dir,
-#                      join(get_natlink_system_config_filename(), "InstallTest")]
-#     dictationtoolboxhome = getenv("DICTATIONTOOLBOXHOME")
-#     if dictationtoolboxhome and os.path.isdir(dictationtoolboxhome):
-#         natlink_config_dir = join(dictationtoolboxhome, '.natlink')
-#         if os.path.isdir(natlink_config_dir):
-#             # logger.info('add sub directory ".natlink" from env variable DICTATIONTOOLBOXHOME to'
-#                             # f'\n\tsearch for a valid config location: "%s"'% natlink_config_dir)
-#             possible_dirs.insert(0, natlink_config_dir)
-#         # else:
-#         #     logger.warning(f'env variable DICTATIONTOOLBOXHOME is set to "{dictationtoolboxhome}", but'
-#         #                         '\n\tno valid directory ".natlink" for the natlink config file is found')
-#     # elif dictationtoolboxhome:
-#     #     logger.warning(f'env variable DICTATIONTOOLBOXHOME is defined, but does not point to a '
-#     #                         f'\n\tvalid directory: "{dictationtoolboxhome}')
-# 
-#     return [expanduser(join(loc, NATLINK_INI)) for loc in possible_dirs]
+    return ([getenv("NATLINK_INI")] if getenv('NATLINK_INI') else
+                [expanduser(join(loc, NATLINK_INI)) for loc in possible_dirs])
 
 def run() -> None:
     logger = logging.getLogger('natlink')


### PR DESCRIPTION
message of inno-code.iss when Dragon is still running, bit of config.py and loader.py
details of _meet_natlink.py (mere exercise)...

Nils, can you merge these in? See near bottom of loader.py. I would prefer config_locations insider the class, so logger info can be given (see commented out version.) 

Can this be done by splitting up the call 
config = NatlinkConfig.from_first_found_file(config_locations())
4 lines from the bottom?

Oops, not the very last change: I forgot to save line 225 of f config_locations() -> Iterable[str]:
can you put de in front of it (def). Sorry.