### PR TITLE
Ensure static linking for CMAKE >=3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ if (NOT(Python3_FOUND))
 endif()  
 message(STATUS "Using Python installation found at: ${Python3_EXECUTABLE}")
 
+# Use static linking of MSVC runtime libraries, both in debug and release
+# See https://cmake.org/cmake/help/git-stage/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html#variable:CMAKE_MSVC_RUNTIME_LIBRARY
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
 # Build C++ code, including two versions of _natlink.pyd, the COM server running Python
 add_subdirectory ("NatlinkSource") 
 #  Build the NatlinkModule, that is, depend on the previous step and 

--- a/NatlinkSource/CMakeLists.txt
+++ b/NatlinkSource/CMakeLists.txt
@@ -41,18 +41,6 @@ add_compile_options("/std:c++17") # because of extern/WinReg
 # see note at top of https://docs.python.org/3/c-api/arg.html
 add_compile_definitions(PY_SSIZE_T_CLEAN)
 
-# add_compile_definitions(Py_LIMITED_API) (need?) Stable Application Binary Interface
-
-# Make stdlib and vc runtime be statically linked into the DLL -> fewer dependencies for user
-foreach(flag_var
-        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-    message(STATUS "${flag_var} ${${flag_var}}")
-    if(${flag_var} MATCHES "/MD")
-        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-    endif(${flag_var} MATCHES "/MD")
-endforeach(flag_var)
-
 # Add two DLL libraries to build, one for 15 and one for 13 (which also works for 14).
 add_library(natlink15_pyd SHARED ${SRC_FILES})
 add_library(natlink13_pyd SHARED ${SRC_FILES})


### PR DESCRIPTION
CMAKE 3.15 introduced a change in how certain compilation flags are set. Follow the new model so that MSVC runtime is statically linked into ".pyd" files.