### PR TITLE
Add missing call to finalize the interpreter on NatSpeak shutdown

### DIFF
--- a/NatlinkSource/COM/appsupp.cpp
+++ b/NatlinkSource/COM/appsupp.cpp
@@ -304,6 +304,9 @@ STDMETHODIMP CDgnAppSupport::UnRegister()
 	// free our reference to the Python modules
 	Py_XDECREF( m_pNatlinkModule );
 
+	// finalize the Python interpreter
+	Py_Finalize();
+
 	return S_OK;
 }
 


### PR DESCRIPTION
This pull request adds a missing call to [`Py_Finalize()`](https://docs.python.org/2/c-api/init.html#c.Py_Finalize) in *COM\\appsupp.cpp*.  This should allow things like the `atexit` module to work.

~I have set this as a draft PR for the moment.  Still need to compile and test that this works fine.~