### PR TITLE
fix exception in exception in __init__.py

### DIFF
--- a/pythonsrc/src/natlink/__init__.py
+++ b/pythonsrc/src/natlink/__init__.py
@@ -59,8 +59,8 @@ try:
     from _natlink_core import execScript as _execScript
     from _natlink_core import playString as _playString
     from _natlink_core import recognitionMimic as _recognitionMimic
-except Exception as exc:
-    tb_lines=''.join(traceback.format_exception(exc))
+except Exception:
+    tb_lines = traceback.format_exc()
 
     outputDebugString(f"Python traceback \n{tb_lines}\n in {__file__}")
 


### PR DESCRIPTION
in __init__.py the except clause raised another exception. Therefore no sensible exception message was shown.