### PR TITLE
Add initial DPI v16 support

### DIFF
--- a/InstallerSource/inno-code.iss
+++ b/InstallerSource/inno-code.iss
@@ -17,6 +17,13 @@ var
   TestDir: String;
 begin
   Result := '';
+  TestDir := ExpandConstant('{commonappdata}\Nuance\NaturallySpeaking16');
+  if DirExists(TestDir) then
+  begin
+    Result := TestDir;
+    DragonVersion := '15';
+    exit;
+  end;
   TestDir := ExpandConstant('{commonappdata}\Nuance\NaturallySpeaking15');
   if DirExists(TestDir) then
   begin

--- a/InstallerSource/inno-setup-natlink.iss
+++ b/InstallerSource/inno-setup-natlink.iss
@@ -26,11 +26,13 @@ SolidCompression=yes
 WizardStyle=modern
 SetupLogging=yes
 
+#define NatlinkCorePyd "_natlink_core{code:GetDragonVersion}.pyd"
+
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Messages]
-WelcomeLabel2=Welcome to {#MyAppName} {#MyAppVersion} for%n%nDragon/NaturallySpeaking 13, 14 or 15.
+WelcomeLabel2=Welcome to {#MyAppName} {#MyAppVersion} for%n%nDragon/NaturallySpeaking 13, 14, 15 or 16.
 
 ;[Code]
 #include "inno-code.iss"
@@ -42,7 +44,7 @@ Source: "{#PythonWheelPath}"; DestDir: "{#DistDir}"; \
 
 ;how registration was working before.  but it renamed the pyd and this created
 ;problems when developing.  
-;Source: "{#CoreDir}\_natlink_core{code:GetDragonVersion}.pyd"; DestDir: "{#CoreDir}"; DestName: "_natlink_core.pyd"; \
+;Source: "{#CoreDir}\{#NatlinkCorePyd}"; DestDir: "{#CoreDir}"; DestName: "_natlink_core.pyd"; \
 ;  Flags: ignoreversion external regserver {#Bits}
 
 
@@ -92,13 +94,12 @@ Root: HKCU; Subkey: "{#PythonPathMyAppNameKey}"; ValueType: string; ValueData: "
 Filename: "{code:GetPythonInstallPath}\\Scripts\\pip.exe"; Parameters: "-m pip install --upgrade pip"; StatusMsg: "Upgrade pip..."
 Filename: "{code:GetPythonInstallPath}\\Scripts\\pip.exe"; Parameters: "install --target ""{#SitePackagesDir}""  --upgrade ""{app}/dist/{#PythonWheelName}"" "; StatusMsg: "natlink {#PythonWheelName}"
 
-Filename: "regsvr32";  Parameters: "-s \""{#CoreDir}\_natlink_core{code:GetDragonVersion}.pyd\""" ; StatusMsg: "regsvr32 _natlink_core{code:GetDragonVersion}.pyd"
+Filename: "regsvr32";  Parameters: "-s \""{#CoreDir}\{#NatlinkCorePyd}\""" ; StatusMsg: "regsvr32 {#NatlinkCorePyd}"
 Filename: "{code:GetPythonInstallPath}\\Scripts\\pip.exe"; Parameters: "install --upgrade natlinkcore"; StatusMsg: "natlinkcore"
 
 Filename: "{code:GetPythonInstallPath}\\Scripts\\natlinkconfig_gui.exe"; Parameters: ""; StatusMsg: "Configure Natlink…"
 
 [UninstallRun]
-Filename: "regsvr32";  Parameters: "-s \""{#CoreDir}\_natlink_core15.pyd\""" ; StatusMsg: "regsvr32 -u _natlink_core15.pyd"
-Filename: "regsvr32";  Parameters: "-s \""{#CoreDir}\_natlink_core13.pyd\""" ; StatusMsg: "regsvr32 -u _natlink_core13.pyd"
+Filename: "regsvr32";  Parameters: "-s \""{#CoreDir}\{#NatlinkCorePyd}\""" ; StatusMsg: "regsvr32 -u {#NatlinkCorePyd}"
 Filename: "{code:GetPythonInstallPath}\\Scripts\\pip.exe"; Parameters: "uninstall --yes  natlinkcore natlink"; StatusMsg: "uninstall natlink"
 

--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,7 @@
 
 ## Technical
 
-- Build pyd for Dragon 15 and for 12-14, make installer choose correct dll and move
+- Build pyd for Dragon for 12-16, make installer choose correct dll and move
 - ~~Use link to python3X.pyd, calculated at install time, instead of including it with installer~~
 - Use .pth file to direct our COM server instead of or supplementing registry keys?
 - Correct dependencies on python source files in CMAKE

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -3,7 +3,7 @@ Welcome to Natlink's Documentation!
 
 Natlink is an OpenSource extension module for the speech recognition program [Dragon](https://www.nuance.com/dragon/business-solutions/dragon-professional-individual.html).
 
-Natlink with Python 3 and Dragon 13, 14, or 15, is now in a beta phase for:
+Natlink with Python 3 and Dragon 13, 14, 15, or 16 is now in a beta phase for:
 
 - Dragonfly
 - Vocola and

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Natlink
 
-Natlink is a compatibility module for Dragon NaturallySpeaking (DNS/DPI) v13-v15 on Windows that allows the user to run Python scripts that interact with DNS. 
+Natlink is a compatibility module for Dragon NaturallySpeaking (DNS/DPI) v13-v16 on Windows that allows the user to run Python scripts that interact with DNS. 
 
 Documentation available at [natlink.reddthedocs.io](https://natlink.readthedocs.io/en/latest/) or in the documentation folder of the github repository.
 


### PR DESCRIPTION
The adds initial support for DPI v16. This simply adds the required path for `inno-code.iss`

**Todo**:
- [x] Edit documentation to reflect DPI v16 support

**Other thoughts**
However I think how we handle version numbers within `inno-code.iss` could improved.

- Better handling of logic when DNS 13 Compiled C++ code is not compatible with DPI 14/15/16
	-  `DragonVersion := '15';`  actually handles DragonVersion 14/15/16 this should be reflected better within the code without relying on absolute version numbers.
