### PR TITLE
Add Natlink Python Environment Bat Shortcut and optimize set up install

### DIFF
--- a/InstallerSource/inno-code.iss
+++ b/InstallerSource/inno-code.iss
@@ -5,6 +5,7 @@ var
 
   CancelWithoutPrompt: Boolean;
   DragonVersion: Integer;
+  PythonInstallPath: String;
 
 procedure CancelButtonClick(CurPageID: Integer; var Cancel, Confirm: Boolean);
 begin
@@ -224,4 +225,14 @@ end;
 function GetDragonIniDir(Param: String): String;
 begin
   Result := DragonIniPage.Values[0];
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+// SetPythonInstallPathBat
+begin
+  if CurStep = ssInstall then
+  begin
+  PythonInstallPath := GetPythonInstallPath('');
+  SaveStringToFile(ExpandConstant('{app}')+'\python_environment.bat', 'cmd /k cd ' + PythonInstallPath, False);
+  end;
 end;

--- a/InstallerSource/inno-setup-natlink.iss
+++ b/InstallerSource/inno-setup-natlink.iss
@@ -53,6 +53,7 @@ Source: "{#PythonWheelPath}"; DestDir: "{#DistDir}"; \
 Name: "{group}\Configure Natlink via GUI"; Filename: "{#PythonInstallPath}\\Scripts\\natlinkconfig_gui.exe"; WorkingDir: "{#PythonInstallPath}\\Scripts"
 Name: "{group}\Configure Natlink via CLI"; Filename: "{#PythonInstallPath}\\Scripts\\natlinkconfig_cli.exe"; WorkingDir: "{#PythonInstallPath}\\Scripts"
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
+Name: "{group}\Natlink Python Environment"; Filename: "{app}\python_environment.bat"; WorkingDir: "{app}"
 
 [INI]                                                    
 Filename: "{code:GetDragonIniDir}\nssystem.ini"; Section: "Global Clients"; Key: ".{#MyAppName}"; \

--- a/InstallerSource/inno-setup-natlink.iss
+++ b/InstallerSource/inno-setup-natlink.iss
@@ -27,6 +27,7 @@ WizardStyle=modern
 SetupLogging=yes
 
 #define NatlinkCorePyd "{code:GetGetPydName}"
+#define PythonInstallPath "{code:GetPythonInstallPath}"
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -49,8 +50,8 @@ Source: "{#PythonWheelPath}"; DestDir: "{#DistDir}"; \
 
 
 [Icons]
-Name: "{group}\Configure Natlink via GUI"; Filename: "{code:GetPythonInstallPath}\\Scripts\\natlinkconfig_gui.exe"; WorkingDir: "{code:GetPythonInstallPath}\\Scripts"
-Name: "{group}\Configure Natlink via CLI"; Filename: "{code:GetPythonInstallPath}\\Scripts\\natlinkconfig_cli.exe"; WorkingDir: "{code:GetPythonInstallPath}\\Scripts"
+Name: "{group}\Configure Natlink via GUI"; Filename: "{#PythonInstallPath}\\Scripts\\natlinkconfig_gui.exe"; WorkingDir: "{#PythonInstallPath}\\Scripts"
+Name: "{group}\Configure Natlink via CLI"; Filename: "{#PythonInstallPath}\\Scripts\\natlinkconfig_cli.exe"; WorkingDir: "{#PythonInstallPath}\\Scripts"
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 
 [INI]                                                    
@@ -76,7 +77,7 @@ Root: HKLM; Subkey: "Software\{#MyAppName}"; ValueType: string; ValueName: "vers
 
 ; Add a key for natlink COM server (_natlink_corexx.pyd) to find the Python installation
 ; If GetPythonInstallPath fails, then the error will be reported as per [Code] section
-Root: HKLM; Subkey: "Software\{#MyAppName}"; ValueType: string; ValueName: "pythonInstallPath"; ValueData: "{code:GetPythonInstallPath}"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "Software\{#MyAppName}"; ValueType: string; ValueName: "pythonInstallPath"; ValueData: "{#PythonInstallPath}"; Flags: uninsdeletekey
 
 ; Register natlink with command line invocations of Python: the Natlink site packages directory
 ; is added as an additonal site package directory to sys.path during interpreter initialization.
@@ -91,15 +92,15 @@ Root: HKCU; Subkey: "{#PythonPathMyAppNameKey}"; ValueType: string; ValueData: "
 
 [Run]
 ;register the pyd for corresponding version of Python
-Filename: "{code:GetPythonInstallPath}\\Scripts\\pip.exe"; Parameters: "-m pip install --upgrade pip"; StatusMsg: "Upgrade pip..."
-Filename: "{code:GetPythonInstallPath}\\Scripts\\pip.exe"; Parameters: "install --target ""{#SitePackagesDir}""  --upgrade ""{app}/dist/{#PythonWheelName}"" "; StatusMsg: "natlink {#PythonWheelName}"
+Filename: "{#PythonInstallPath}\\Scripts\\pip.exe"; Parameters: "-m pip install --upgrade pip"; StatusMsg: "Upgrade pip..."
+Filename: "{#PythonInstallPath}\\Scripts\\pip.exe"; Parameters: "install --target ""{#SitePackagesDir}""  --upgrade ""{app}/dist/{#PythonWheelName}"" "; StatusMsg: "natlink {#PythonWheelName}"
 
 Filename: "regsvr32";  Parameters: "-s \""{#CoreDir}\{#NatlinkCorePyd}\""" ; StatusMsg: "regsvr32 {#NatlinkCorePyd}"
-Filename: "{code:GetPythonInstallPath}\\Scripts\\pip.exe"; Parameters: "install --upgrade natlinkcore"; StatusMsg: "natlinkcore"
+Filename: "{#PythonInstallPath}\\Scripts\\pip.exe"; Parameters: "install --upgrade natlinkcore"; StatusMsg: "natlinkcore"
 
-Filename: "{code:GetPythonInstallPath}\\Scripts\\natlinkconfig_gui.exe"; Parameters: ""; StatusMsg: "Configure Natlink…"
+Filename: "{#PythonInstallPath}\\Scripts\\natlinkconfig_gui.exe"; Parameters: ""; StatusMsg: "Configure Natlink…"
 
 [UninstallRun]
 Filename: "regsvr32";  Parameters: "-s \""{#CoreDir}\{#NatlinkCorePyd}\""" ; StatusMsg: "regsvr32 -u {#NatlinkCorePyd}"
-Filename: "{code:GetPythonInstallPath}\\Scripts\\pip.exe"; Parameters: "uninstall --yes  natlinkcore natlink"; StatusMsg: "uninstall natlink"
+Filename: "{#PythonInstallPath}\\Scripts\\pip.exe"; Parameters: "uninstall --yes  natlinkcore natlink"; StatusMsg: "uninstall natlink"
 


### PR DESCRIPTION
- Added: Natlink Python Environment bat shortcut. Should make it easier for users to get into their Python environment regardless of location or method of install.
- optimizations: There were a lot of calls to `code:GetPythonInstallPath`  which is now contained within a variable `PythonInstallPath `