### PR TITLE
Explicitly free memory allocated

### DIFF
--- a/NatlinkSource/COM/appsupp.cpp
+++ b/NatlinkSource/COM/appsupp.cpp
@@ -195,6 +195,12 @@ std::string DoPyConfig(void) {
 		goto fail;
 	}
 
+	status = PyConfig_SetString(&config, &(config.program_name), L"Python");
+	if (PyStatus_Exception(status)) {
+		init_error = "Natlink: failed to set program_name\n";
+		goto fail;
+	}
+
     status = Py_InitializeFromConfig(&config);
     if (PyStatus_Exception(status)) {
 		init_error = "Natlink: failed initialize from config\n";
@@ -306,6 +312,7 @@ STDMETHODIMP CDgnAppSupport::UnRegister()
 
 	// finalize the Python interpreter
 	Py_Finalize();
+	PyMem_RawFree(L"python");
 
 	return S_OK;
 }


### PR DESCRIPTION
Fixes https://github.com/dictation-toolbox/natlink/issues/141 by setting program_name and explicitly free memory by name ref using PyMem_RawFree

- Tested on DNS 13 and 16

Should be fine on v14/15

While all this does remedy the issue. This is most likely a workaround for a yet unknown underlying issue with python 3 c++ embedded  and dns 13