### PR TITLE
fix GetPythonInstallPath in inno-setup-natlink.iss

### DIFF
--- a/InstallerSource/inno-setup-natlink.iss
+++ b/InstallerSource/inno-setup-natlink.iss
@@ -42,7 +42,6 @@ WizardStyle=modern
 SetupLogging=yes
 
 #define NatlinkCorePyd "{code:GetGetPydName}"
-#define PythonInstallPath "{code:GetPythonInstallPath}"
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -65,8 +64,8 @@ Source: "{#PythonWheelPath}"; DestDir: "{#DistDir}"; \
 
 
 [Icons]
-Name: "{group}\Configure Natlink via GUI"; Filename: "{#PythonInstallPath}\\Scripts\\natlinkconfig_gui.exe"; WorkingDir: "{#PythonInstallPath}\\Scripts"
-Name: "{group}\Configure Natlink via CLI"; Filename: "{#PythonInstallPath}\\Scripts\\natlinkconfig_cli.exe"; WorkingDir: "{#PythonInstallPath}\\Scripts"
+Name: "{group}\Configure Natlink via GUI"; Filename: "{code:GetPythonInstallPath}\\Scripts\\natlinkconfig_gui.exe"; WorkingDir: "{code:GetPythonInstallPath}\\Scripts"
+Name: "{group}\Configure Natlink via CLI"; Filename: "{code:GetPythonInstallPath}\\Scripts\\natlinkconfig_cli.exe"; WorkingDir: "{code:GetPythonInstallPath}\\Scripts"
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 Name: "{group}\Natlink Python Environment"; Filename: "{app}\python_environment.bat"; WorkingDir: "{app}"
 
@@ -93,7 +92,7 @@ Root: HKLM; Subkey: "Software\{#MyAppName}"; ValueType: string; ValueName: "vers
 
 ; Add a key for natlink COM server (_natlink_corexx.pyd) to find the Python installation
 ; If GetPythonInstallPath fails, then the error will be reported as per [Code] section
-Root: HKLM; Subkey: "Software\{#MyAppName}"; ValueType: string; ValueName: "pythonInstallPath"; ValueData: "{#PythonInstallPath}"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "Software\{#MyAppName}"; ValueType: string; ValueName: "{code:GetPythonInstallPath}"; ValueData: "{code:GetPythonInstallPath}"; Flags: uninsdeletekey
 
 ; Register natlink with command line invocations of Python: the Natlink site packages directory
 ; is added as an additonal site package directory to sys.path during interpreter initialization.
@@ -110,19 +109,19 @@ Root: HKCU; Subkey: "{#PythonPathMyAppNameKey}"; ValueType: string; ValueData: "
 ;debugging tip for this section:  Run the setup.exe program with /LOG.  See inno setup docs.
 
 ;register the pyd for corresponding version of Python
-Filename: "{#PythonInstallPath}\\Scripts\\pip.exe"; Parameters: "-m pip install --upgrade pip"; StatusMsg: "Upgrade pip..."
-Filename: "{#PythonInstallPath}\\Scripts\\pip.exe"; Parameters: "install --target ""{#SitePackagesDir}""  --upgrade ""{app}/dist/{#PythonWheelName}"" "; StatusMsg: "natlink {#PythonWheelName}"
+Filename: "{code:GetPythonInstallPath}\\Scripts\\pip.exe"; Parameters: "-m pip install --upgrade pip"; StatusMsg: "Upgrade pip..."
+Filename: "{code:GetPythonInstallPath}\\Scripts\\pip.exe"; Parameters: "install --target ""{#SitePackagesDir}""  --upgrade ""{app}/dist/{#PythonWheelName}"" "; StatusMsg: "natlink {#PythonWheelName}"
 
 ;pip changes the permissions on files and folders, so we have to redo them.  icacls is a built in windows program to change permissions.
 ;users need read and execute  
 
 Filename: "icacls.exe";  Parameters: " ""{#SitePackagesDir}"" /t /grant *{#AllowedUsersSid}:RX "; StatusMsg: "icacls.exe"; 
 Filename: "regsvr32";  Parameters: "-s \""{#CoreDir}\{#NatlinkCorePyd}\""" ; StatusMsg: "regsvr32 {#NatlinkCorePyd}"
-Filename: "{#PythonInstallPath}\\Scripts\\pip.exe"; Parameters: "install --upgrade natlinkcore"; StatusMsg: "natlinkcore"
+Filename: "{code:GetPythonInstallPath}\\Scripts\\pip.exe"; Parameters: "install --upgrade natlinkcore"; StatusMsg: "natlinkcore"
 
-Filename: "{#PythonInstallPath}\\Scripts\\natlinkconfig_gui.exe"; Parameters: ""; StatusMsg: "Configure Natlink…"
+Filename: "{code:GetPythonInstallPath}\\Scripts\\natlinkconfig_gui.exe"; Parameters: ""; StatusMsg: "Configure Natlink…"
 
 [UninstallRun]
 Filename: "regsvr32";  Parameters: "-s \""{#CoreDir}\{#NatlinkCorePyd}\""" ; StatusMsg: "regsvr32 -u {#NatlinkCorePyd}"
-Filename: "{#PythonInstallPath}\\Scripts\\pip.exe"; Parameters: "uninstall --yes  natlinkcore natlink"; StatusMsg: "uninstall natlink"
+Filename: "{code:GetPythonInstallPath}\\Scripts\\pip.exe"; Parameters: "uninstall --yes  natlinkcore natlink"; StatusMsg: "uninstall natlink"
 


### PR DESCRIPTION
Should fix https://github.com/dictation-toolbox/natlink/issues/175
[natlink5.5.6-py3.10-32-setup.zip](https://github.com/dictation-toolbox/natlink/files/13263311/natlink5.5.6-py3.10-32-setup.zip)


@dougransom could you test the installer?