### PR TITLE
Fordragon16, failed attempt to implement playEvents via python

### DIFF
--- a/pythonsrc/pyproject.toml
+++ b/pythonsrc/pyproject.toml
@@ -19,7 +19,7 @@ classifiers=[
     "Topic :: Software Development :: Libraries :: Python Modules"
     ]
 dependencies=[
-    "dtactions >= 1.6.1"
+    
 ]
     
 [project.urls]

--- a/pythonsrc/src/natlink/__init__.py
+++ b/pythonsrc/src/natlink/__init__.py
@@ -14,6 +14,8 @@ import traceback
 import winreg
 import ctypes
 import contextlib
+import win32api
+import win32gui
 from dtactions.vocola_sendkeys import ext_keys
 W32OutputDebugString = ctypes.windll.kernel32.OutputDebugStringW
 
@@ -82,11 +84,29 @@ def playString(a, hook=0):
     # normal case:
     return ext_keys.send_input(a)
 
+def playEvents16(events):
+    """a short version, written by Dany Finlay
+    """
+    print(f'try a playEvents on Dragon16: {events}')
+    # Check that *events* is a list.
+    if not isinstance(events, list):
+        raise TypeError("events must be a list of 3-tuples")
+
+    # Post each 3-tuple event to the foreground window.
+    hwnd = win32gui.GetForegroundWindow()
+    for event in events:
+        if not (isinstance(event, tuple) and len(event) == 3 and
+                all((isinstance(i, int) for i in event))):
+            raise TypeError("events must be a list containing 3-tuples of"
+                            " integers")
+        message, wParam, lParam = event
+        win32api.PostMessage(hwnd, message, wParam, lParam)
+
 def playEvents(a):
     """causes a halt (ESP error) in Dragon 16.
     """
     if getDNSVersion() >= 16:
-        outputDebugString("ignore playEvents, it halts with Dragon 16 (ESP error)")
+        playEvents16(a)
         return None
     return _playEvents(a)
 
@@ -152,6 +172,7 @@ def NatlinkConnector():
 
 if __name__ == "__main__":
     outputDebugString(f'getDNSVersion: {getDNSVersion()} (type: {type(getDNSVersion())}))')
-    playString('abcde')
-    playEvents(tuple())
+    # playString('abcde')
+    playEvents( [(0,0,0)] )
+    
     

--- a/pythonsrc/src/natlink/__init__.py
+++ b/pythonsrc/src/natlink/__init__.py
@@ -170,9 +170,23 @@ def NatlinkConnector():
     natDisconnect()
 
 
+def _test_playEvents():
+    """perform a few mouse moves
+    """
+    import time
+    wm_mousemove = 0x0200
+    positionsx = [10, 500, 500, 10, 10]
+    positionsy = [10, 10, 500, 500, 10]
+    for x, y in zip(positionsx, positionsy):
+        playEvents( [(wm_mousemove, x, y)] )
+        time.sleep(1)
+            
+            
+
 if __name__ == "__main__":
     outputDebugString(f'getDNSVersion: {getDNSVersion()} (type: {type(getDNSVersion())}))')
     # playString('abcde')
-    playEvents( [(0,0,0)] )
-    
+    # playEvents( [(0,0,0)] )
+    _test_playEvents()
+        
     

--- a/pythonsrc/src/natlink/__init__.py
+++ b/pythonsrc/src/natlink/__init__.py
@@ -16,7 +16,7 @@ import ctypes
 import contextlib
 import win32api
 import win32gui
-from dtactions.vocola_sendkeys import ext_keys
+from dtactions.vocola_sendkeys import ext_keys   ### , SendInput
 W32OutputDebugString = ctypes.windll.kernel32.OutputDebugStringW
 
 #copied from pydebugstring.  
@@ -84,6 +84,7 @@ def playString(a, hook=0):
     # normal case:
     return ext_keys.send_input(a)
 
+
 def playEvents16(events):
     """a short version, written by Dany Finlay
     """
@@ -92,15 +93,22 @@ def playEvents16(events):
     if not isinstance(events, list):
         raise TypeError("events must be a list of 3-tuples")
 
-    # Post each 3-tuple event to the foreground window.
-    hwnd = win32gui.GetForegroundWindow()
-    for event in events:
-        if not (isinstance(event, tuple) and len(event) == 3 and
-                all((isinstance(i, int) for i in event))):
-            raise TypeError("events must be a list containing 3-tuples of"
-                            " integers")
-        message, wParam, lParam = event
-        win32api.PostMessage(hwnd, message, wParam, lParam)
+    print('playEvents not implemented for Dragon 16 (yet)')
+    # try to attach to (repository) \dtactions\vocola_sendkeys
+    # SendInput.send_input(events)
+
+
+    # this is the attempt of Dane, which fails.
+    # # Post each 3-tuple event to the foreground window.
+    # hwnd = win32gui.GetForegroundWindow()
+    # for event in events:
+    #     if not (isinstance(event, tuple) and len(event) == 3 and
+    #             all((isinstance(i, int) for i in event))):
+    #         raise TypeError("events must be a list containing 3-tuples of"
+    #                         " integers")
+    #     
+    #     message, wParam, lParam = event
+    #     win32api.PostMessage(hwnd, message, wParam, lParam)
 
 def playEvents(a):
     """causes a halt (ESP error) in Dragon 16.


### PR DESCRIPTION
two attempts to implement natlink.playEvents via python failed:

1. Dane suggested via win32api.PostMessage
2. Via the SendInput module of Vocola (Mark Lillibridge).

I think either this module can be adapted for direct playEvents inputs, or the wanted playEvents actions in grammars can be implemented via this module or via the appropriate Dragonfly module.

