### PR TITLE
Fix two grammar callbacks that silently fail out-of-process

### DIFF
--- a/NatlinkSource/DragonCode.cpp
+++ b/NatlinkSource/DragonCode.cpp
@@ -1821,7 +1821,9 @@ BOOL CDragonCode::natConnect( IServiceProvider * pIDgnSite, BOOL bUseThreads )
 	{
 		PyThreadState * threadStateSave = PyThreadState_Swap( NULL );
 		assert( threadStateSave != NULL );
-		m_pThreadState = PyThreadState_New( threadStateSave->interp );
+		// DF: Simple assignment works better than PyThreadState_New().
+		//m_pThreadState = PyThreadState_New( threadStateSave->interp );
+		m_pThreadState = threadStateSave;
 		PyThreadState_Swap( threadStateSave );
 	}
 

--- a/NatlinkSource/GrammarObject.cpp
+++ b/NatlinkSource/GrammarObject.cpp
@@ -120,7 +120,10 @@ STDMETHODIMP CSRGramNotifySink::PhraseFinish(
 
 	if( m_pParent )
 	{
+		// This call requires Python's GIL to be held.
+		PyGILState_STATE gstate = PyGILState_Ensure();
 		m_pParent->PhraseFinish( dwFlags, pSRPhrase, pIUnknown );
+		PyGILState_Release( gstate );
 	}
 
 	return S_OK;
@@ -136,7 +139,10 @@ STDMETHODIMP CSRGramNotifySink::PhraseHypothesis(
 
 	if( m_pParent )
 	{
+		// This call requires Python's GIL to be held.
+		PyGILState_STATE gstate = PyGILState_Ensure();
 		m_pParent->PhraseHypothesis( dwFlags, pSRPhrase );
+		PyGILState_Release( gstate );
 	}
 
 	return S_OK;


### PR DESCRIPTION
I made this change a month ago.  I figure it should probably be submitted on its own.

Commit text:
> The grammar recognition and hypothesis callbacks have been silently failing on Windows 10 when Natlink is used in a separate Python process.  Holding the GIL during the callbacks and making a minor change in the natConnect() function fixes this problem.

The error may be reproduced out of process using a loaded grammar and the `waitForSpeech()` function.  The Dragon log should have a line or two saying that client process python.exe failed with error `RPC_E_SERVERFAULT`.