### PR TITLE
Make natDisconnect() be called upon ext module deallocation

### DIFF
--- a/NatlinkSource/DragonCode.cpp
+++ b/NatlinkSource/DragonCode.cpp
@@ -694,6 +694,13 @@ BOOL CDragonCode::isNatSpeakRunning()
 
 //---------------------------------------------------------------------------
 
+void CDragonCode::freeModule()
+{
+	natDisconnect();
+}
+
+//---------------------------------------------------------------------------
+
 void CDragonCode::releaseObjects()
 {
 	// iterate over all the grammar objects and free them; note that when we

--- a/NatlinkSource/DragonCode.h
+++ b/NatlinkSource/DragonCode.h
@@ -114,6 +114,10 @@ class CDragonCode
 	void setAppClass( CDgnAppSupport * pAppClass ) { m_pAppClass = pAppClass; }
 	void setDuringInit( BOOL bState ) { m_bDuringInit = bState; }
 
+	// this is called when the natlink module (this class!) is deallocated from
+	// Python
+	void freeModule();
+
 	// these functions are called from CGrammarObject
 	ISRCentral * pISRCentral() { return m_pISRCentral; }
 	void addGramObj(CGrammarObject * pGramObj );

--- a/NatlinkSource/pythwrap.cpp
+++ b/NatlinkSource/pythwrap.cpp
@@ -2318,15 +2318,27 @@ static struct PyMethodDef natlink_methods[] = {
 };
 
 //---------------------------------------------------------------------------
+// natlink module free function.
+
+void natlink_free( void * p )
+{
+	cDragon.freeModule();
+}
+
+//---------------------------------------------------------------------------
 // import natlink from Python
 //
 // We tell Python about our functions and also create an error type.
 static struct PyModuleDef NatlinkModule = {
-		PyModuleDef_HEAD_INIT,
-		"_natlink_core",   /* name of module */
-		"natlink with python3 compatability",
-		-1,
-		natlink_methods
+		PyModuleDef_HEAD_INIT,                 /* m_base */
+		"_natlink_core",                       /* m_name */
+		"natlink with python3 compatability",  /* m_doc */
+		-1,                                    /* m_size */
+		natlink_methods,                       /* m_methods */
+		NULL,                                  /* m_slots */
+		NULL,                                  /* m_traverse */
+		NULL,                                  /* m_clear */
+		natlink_free                           /* m_free */
 };
 
 


### PR DESCRIPTION
These changes make it so the natDisconnect() function is called for you automatically if you forget it.  No effect in-process.