### PR TITLE
Fix an error in appsupp.cpp which causes a natspeak.exe crash

### DIFF
--- a/NatlinkSource/COM/appsupp.cpp
+++ b/NatlinkSource/COM/appsupp.cpp
@@ -378,8 +378,6 @@ STDMETHODIMP CDgnAppSupport::UnRegister()
 
 	Py_Finalize();
 
-	PyMem_RawFree(L"python");
-
 	// finalize the Python interpreter
 	OutputDebugString( TEXT( "CDgnAppSupport::UnRegister, exit UnRegister" ) );
 


### PR DESCRIPTION
Re: #217.

The PyMem_RawFree() call in this file, in CDgnAppSupport::UnRegister(), causes Dragon to crash on exit.  So I am removing it here.