### PR TITLE
corrected use of build module.

### DIFF
--- a/docs/building_natlink.md
+++ b/docs/building_natlink.md
@@ -24,7 +24,10 @@ instructions below.
 
 5. Install [Inno](https://jrsoftware.org/isdl.php) version 6.x. - 
    - Inno Setup compiler iscc.exe needs to be sys PATH.
-6. Install flit to Python 3.10.x 32-bit interpreter `py -3.10-32 -m pip install flit`
+
+6.  Instally the pyproject-build command.   This builds python modules in isolated enironments.  A good idea to have on your system.
+     You can install pipx https://pipx.pypa.io/stable/installation/ (also a good idea) then `pipx installl build`.  Or install build on any python on your system that will be in the path.  You can even use natlink's 32 bit python if you want, though it unecessarily brings build into that environment.
+
    
 ### Building Natlink
 

--- a/pythonsrc/CMakeLists.txt
+++ b/pythonsrc/CMakeLists.txt
@@ -35,7 +35,9 @@ add_custom_command(
     OUTPUT "${WHEEL_PATH}"
     COMMENT "Building python wheel package in ${WHEEL_PATH}"
     COMMAND ${CMAKE_COMMAND} -E  copy ${NL_FILES}  ${NL_PY_DIR}
-    COMMAND ${Python3_EXECUTABLE} -m build
+    #COMMAND ${Python3_EXECUTABLE} -m build
+    COMMAND pyproject-build
+
     DEPENDS StampDriver # otherwise the stamps are not checked
         ${PROJECT_BINARY_DIR}/NatlinkSource/NatlinkSource.STAMP
         ${NL_FILES}


### PR DESCRIPTION
Build doesn't have to be python32 or the same python you are using in your project.  In fact it shouldn't be.

In the build projects https://github.com/pypa/build/blob/main/pyproject.toml#L54 you can see they publish a script.


```
[project.scripts]
pyproject-build = "build.__main__:entrypoint"

```
make sure project-build is in your path.  If you installed it in your python environment it will be in the same folder as python.exe.

If you installed it with pipx (recommended), it will be in the appropriate place.

Those who have been installing build in their 32 bit python environment for natlink should be able to build without doing anything as that script should be in the path (if the 32 bit python is in the path anyway).

