### PR TITLE
Fix DPI 16 callback PlayString and PlayEvents

### DIFF
--- a/NatlinkSource/COM/dspeech.h
+++ b/NatlinkSource/COM/dspeech.h
@@ -428,12 +428,12 @@ DECLARE_INTERFACE_ (IDgnSSvcOutputEventA , IUnknown )
 	STDMETHOD_(ULONG,Release)  (THIS) PURE;
 
 	STDMETHOD (Register) (THIS_ IDgnSSvcActionNotifySink* ) PURE;
-	STDMETHOD (PlayString) (THIS_ const char*, DWORD, DWORD, DWORD, 
-		DWORD* ) PURE;
-	STDMETHOD (NameFromKey) (THIS_ DWORD, DWORD, DWORD, DWORD, 
+	STDMETHOD (PlayString) (THIS_ const char*, DWORD, DWORD, DWORD,
+		DWORD*, DWORD ) PURE;
+	STDMETHOD (NameFromKey) (THIS_ DWORD, DWORD, DWORD, DWORD,
 		char*, DWORD* ) PURE;
 	STDMETHOD (PlayEvents) (THIS_ DWORD, const HOOK_EVENTMSG [], DWORD,
-		DWORD) PURE;
+		DWORD, DWORD) PURE;
 };
 
 // IDgnSSvcOutputEventW
@@ -441,7 +441,7 @@ DECLARE_INTERFACE_ (IDgnSSvcOutputEventA , IUnknown )
 #undef   INTERFACE
 #define  INTERFACE   IDgnSSvcOutputEventW
 
-DEFINE_GUID( IID_IDgnSSvcOutputEventW, 
+DEFINE_GUID( IID_IDgnSSvcOutputEventW,
 	0xdd109201, 0x6205, 0x11cf, 0xae, 0x61,
 	0x00, 0x00, 0xe8, 0xa2, 0x86, 0x47);
 
@@ -453,12 +453,12 @@ DECLARE_INTERFACE_ (IDgnSSvcOutputEventW , IUnknown )
 	STDMETHOD_(ULONG,Release)  (THIS) PURE;
 
 	STDMETHOD (Register) (THIS_ IDgnSSvcActionNotifySink* ) PURE;
-	STDMETHOD (PlayString) (THIS_ const wchar_t*, DWORD, DWORD, DWORD, 
-		DWORD* ) PURE;
-	STDMETHOD (NameFromKey) (THIS_ DWORD, DWORD, DWORD, DWORD, 
+	STDMETHOD (PlayString) (THIS_ const wchar_t*, DWORD, DWORD, DWORD,
+		DWORD*, DWORD ) PURE;
+	STDMETHOD (NameFromKey) (THIS_ DWORD, DWORD, DWORD, DWORD,
 		wchar_t*, DWORD* ) PURE;
 	STDMETHOD (PlayEvents) (THIS_ DWORD, const HOOK_EVENTMSG [], DWORD,
-		DWORD) PURE;
+		DWORD, DWORD) PURE;
 };
 
 #ifdef _S_UNICODE

--- a/NatlinkSource/DragonCode.cpp
+++ b/NatlinkSource/DragonCode.cpp
@@ -1728,6 +1728,15 @@ BOOL CDragonCode::natConnect( IServiceProvider * pIDgnSite, BOOL bUseThreads )
 		__uuidof(IDgnSREngineControl), (void**)&m_pIDgnSREngineControl );
 	RETURNIFERROR( rc, "ISRCentral::QueryInterface(IDgnSREngineControl)" );
 
+	// Detect Dragon version — DNS 16 has different COM calling conventions.
+	{
+		WORD wMajor = 0, wMinor = 0, wBuild = 0;
+		rc = m_pIDgnSREngineControl->GetVersion(&wMajor, &wMinor, &wBuild);
+		if (SUCCEEDED(rc)) {
+			m_dragonMajorVersion = wMajor;
+		}
+	}
+
 	// get the speech services interfaces
 
 	IDgnSpeechServicesPtr pSpchSvc;
@@ -2015,32 +2024,37 @@ BOOL CDragonCode::playString( const char * pszKeys, DWORD dwFlags )
 	DWORD dwClientCode = ++dwUnique;
 
 	DWORD dwNumUndo=0;
-		
 
-	#ifdef UNICODE
+	if (m_dragonMajorVersion >= 16) {
+		// DNS 16 added a 6th parameter to PlayString that controls whether
+		// the PlaybackDone callback fires.  Passing 0 = fire-and-forget
+		// (no callback), non-zero = notify via PlaybackDone.
+		// The callee does ret 28 (this + 6 params), so we must use raw
+		// vtable calls to avoid ESP corruption with the 5-param header.
+		void** vtable = *(void***)((IUnknown*)m_pIDgnSSvcOutputEvent);
+		void* pfnPlayString = vtable[4];  // slot 4 = PlayString
+		void* pThis = (void*)m_pIDgnSSvcOutputEvent;
+		DWORD* pNumUndo = &dwNumUndo;
+		HRESULT comRc;
 
+		__asm {
+			push 1                    // [5] DWORD dwNotify — non-zero for PlaybackDone
+			push pNumUndo             // [4] DWORD* pNumUndo
+			push dwClientCode         // [3] DWORD dwClientCode
+			push 0xFFFFFFFF           // [2] DWORD dwDelay (-1)
+			push dwFlags              // [1] DWORD dwFlags
+			push pszKeys              // [0] const char* pszKeys
+			push pThis                // this
+			call pfnPlayString
+			mov comRc, eax
+		}
 
-	rc = m_pIDgnSSvcOutputEventA->PlayString(
-		pszKeys,	// string to send
-		dwFlags,		// flags
-		0xFFFFFFFF,		// delay (-1 for app specific delay)
-		dwClientCode,	// to identify which WM_PLAYBACK is ours
-		&dwNumUndo );
-
-	int const inputCodePage = CP_UTF8;
-	int const outputCodePage = 1252;
-
-
-
-
-	#else
+		rc = comRc;
+	} else {
+		// DNS 13/15: standard 5-param COM call
 		rc = m_pIDgnSSvcOutputEvent->PlayString(
-			pszKeys, 	  // string to send
-			dwFlags,	  // flags
-			0xFFFFFFFF,   // delay (-1 for app specific delay)
-			dwClientCode, // to identify which WM_PLAYBACK is ours
-			&dwNumUndo ); // not used (number of backspaces needed to undo)
-	#endif
+			pszKeys, dwFlags, 0xFFFFFFFF, dwClientCode, &dwNumUndo );
+	}
 
 
 	RETURNIFERROR( rc, "IDgnSSvcOutputEvent::PlayString" );
@@ -2586,10 +2600,32 @@ BOOL CDragonCode::playEvents( DWORD dwCount, HOOK_EVENTMSG * pEvents )
 	static DWORD dwUnique = 1;
 	DWORD dwClientCode = ++dwUnique;
 
-	rc = m_pIDgnSSvcOutputEvent->PlayEvents(
-		dwCount, pEvents,
-		0xFFFFFFFF,   	// delay (-1 for app specific delay)
-		dwClientCode ); // to identify which WM_PLAYBACK is ours
+	if (m_dragonMajorVersion >= 16) {
+		// DNS 16 added a 5th parameter to PlayEvents that controls whether
+		// the PlaybackDone callback fires (same as PlayString's 6th param).
+		// The callee does ret 24 (this + 5 params), so raw vtable call needed.
+		void** vtable = *(void***)((IUnknown*)m_pIDgnSSvcOutputEvent);
+		void* pfnPlayEvents = vtable[6];  // slot 6 = PlayEvents
+		void* pThis = (void*)m_pIDgnSSvcOutputEvent;
+		HRESULT comRc;
+
+		__asm {
+			push 1                    // [4] DWORD dwNotify — non-zero for PlaybackDone
+			push dwClientCode         // [3] DWORD dwClientCode
+			push 0xFFFFFFFF           // [2] DWORD dwDelay (-1)
+			push pEvents              // [1] const HOOK_EVENTMSG*
+			push dwCount              // [0] DWORD dwCount
+			push pThis                // this
+			call pfnPlayEvents
+			mov comRc, eax
+		}
+
+		rc = comRc;
+	} else {
+		// DNS 13/15: standard 4-param COM call
+		rc = m_pIDgnSSvcOutputEvent->PlayEvents(
+			dwCount, pEvents, 0xFFFFFFFF, dwClientCode );
+	}
 	RETURNIFERROR( rc, "IDgnSSvcOutputEvent::PlayEvents" );
 
 	// Now we want to wait until the playback finishes or is aborted

--- a/NatlinkSource/DragonCode.cpp
+++ b/NatlinkSource/DragonCode.cpp
@@ -1728,15 +1728,6 @@ BOOL CDragonCode::natConnect( IServiceProvider * pIDgnSite, BOOL bUseThreads )
 		__uuidof(IDgnSREngineControl), (void**)&m_pIDgnSREngineControl );
 	RETURNIFERROR( rc, "ISRCentral::QueryInterface(IDgnSREngineControl)" );
 
-	// Detect Dragon version — DNS 16 has different COM calling conventions.
-	{
-		WORD wMajor = 0, wMinor = 0, wBuild = 0;
-		rc = m_pIDgnSREngineControl->GetVersion(&wMajor, &wMinor, &wBuild);
-		if (SUCCEEDED(rc)) {
-			m_dragonMajorVersion = wMajor;
-		}
-	}
-
 	// get the speech services interfaces
 
 	IDgnSpeechServicesPtr pSpchSvc;
@@ -1753,6 +1744,9 @@ BOOL CDragonCode::natConnect( IServiceProvider * pIDgnSite, BOOL bUseThreads )
 		__uuidof(IDgnSSvcOutputEventA), (void**)&m_pIDgnSSvcOutputEventA);
 	RETURNIFERROR( rc, "IDgnSSvcOutputEventA::QueryInterface(DgnSSvcOutputEventA)" );
 
+	rc = pSpchSvc->QueryInterface(
+		__uuidof(IDgnSSvcOutputEventW), (void**)&m_pIDgnSSvcOutputEventW);
+	RETURNIFERROR( rc, "IDgnSSvcOutputEventW::QueryInterface(DgnSSvcOutputEventW)" );
 
 	rc = m_pIDgnSSvcOutputEvent->QueryInterface(
 		__uuidof(IDgnSSvcInterpreter), (void**)&m_pIDgnSSvcInterpreter );
@@ -1897,6 +1891,10 @@ BOOL CDragonCode::natDisconnect()
 	m_pIDgnSREngineControl = NULL;
 	m_pIDgnSSvcOutputEvent = NULL;
 	m_pIDgnSSvcOutputEventA = NULL;
+	if (m_pIDgnSSvcOutputEventW) {
+		m_pIDgnSSvcOutputEventW->Release();
+		m_pIDgnSSvcOutputEventW = NULL;
+	}
 	m_pIDgnExtModSupStrings = NULL;
 	m_pIServiceProvider = NULL;
 	m_pIDgnSSvcInterpreter = NULL;
@@ -2025,35 +2023,15 @@ BOOL CDragonCode::playString( const char * pszKeys, DWORD dwFlags )
 
 	DWORD dwNumUndo=0;
 
-	if (m_dragonMajorVersion >= 16) {
-		// DNS 16 added a 6th parameter to PlayString that controls whether
-		// the PlaybackDone callback fires.  Passing 0 = fire-and-forget
-		// (no callback), non-zero = notify via PlaybackDone.
-		// The callee does ret 28 (this + 6 params), so we must use raw
-		// vtable calls to avoid ESP corruption with the 5-param header.
-		void** vtable = *(void***)((IUnknown*)m_pIDgnSSvcOutputEvent);
-		void* pfnPlayString = vtable[4];  // slot 4 = PlayString
-		void* pThis = (void*)m_pIDgnSSvcOutputEvent;
-		DWORD* pNumUndo = &dwNumUndo;
-		HRESULT comRc;
+	// Use the Unicode interface — the ANSI implementation accepts but
+	// ignores the notify parameter.  Convert to wide string for the W call.
+	{
+		int cchWide = MultiByteToWideChar(CP_ACP, 0, pszKeys, -1, NULL, 0);
+		wchar_t * pwszKeys = (wchar_t *)_alloca(cchWide * sizeof(wchar_t));
+		MultiByteToWideChar(CP_ACP, 0, pszKeys, -1, pwszKeys, cchWide);
 
-		__asm {
-			push 1                    // [5] DWORD dwNotify — non-zero for PlaybackDone
-			push pNumUndo             // [4] DWORD* pNumUndo
-			push dwClientCode         // [3] DWORD dwClientCode
-			push 0xFFFFFFFF           // [2] DWORD dwDelay (-1)
-			push dwFlags              // [1] DWORD dwFlags
-			push pszKeys              // [0] const char* pszKeys
-			push pThis                // this
-			call pfnPlayString
-			mov comRc, eax
-		}
-
-		rc = comRc;
-	} else {
-		// DNS 13/15: standard 5-param COM call
-		rc = m_pIDgnSSvcOutputEvent->PlayString(
-			pszKeys, dwFlags, 0xFFFFFFFF, dwClientCode, &dwNumUndo );
+		rc = m_pIDgnSSvcOutputEventW->PlayString(
+			pwszKeys, dwFlags, 0xFFFFFFFF, dwClientCode, &dwNumUndo, 1 );
 	}
 
 
@@ -2600,32 +2578,10 @@ BOOL CDragonCode::playEvents( DWORD dwCount, HOOK_EVENTMSG * pEvents )
 	static DWORD dwUnique = 1;
 	DWORD dwClientCode = ++dwUnique;
 
-	if (m_dragonMajorVersion >= 16) {
-		// DNS 16 added a 5th parameter to PlayEvents that controls whether
-		// the PlaybackDone callback fires (same as PlayString's 6th param).
-		// The callee does ret 24 (this + 5 params), so raw vtable call needed.
-		void** vtable = *(void***)((IUnknown*)m_pIDgnSSvcOutputEvent);
-		void* pfnPlayEvents = vtable[6];  // slot 6 = PlayEvents
-		void* pThis = (void*)m_pIDgnSSvcOutputEvent;
-		HRESULT comRc;
-
-		__asm {
-			push 1                    // [4] DWORD dwNotify — non-zero for PlaybackDone
-			push dwClientCode         // [3] DWORD dwClientCode
-			push 0xFFFFFFFF           // [2] DWORD dwDelay (-1)
-			push pEvents              // [1] const HOOK_EVENTMSG*
-			push dwCount              // [0] DWORD dwCount
-			push pThis                // this
-			call pfnPlayEvents
-			mov comRc, eax
-		}
-
-		rc = comRc;
-	} else {
-		// DNS 13/15: standard 4-param COM call
-		rc = m_pIDgnSSvcOutputEvent->PlayEvents(
-			dwCount, pEvents, 0xFFFFFFFF, dwClientCode );
-	}
+	// Use the Unicode interface — the ANSI implementation accepts but
+	// ignores the notify parameter.
+	rc = m_pIDgnSSvcOutputEventW->PlayEvents(
+		dwCount, pEvents, 0xFFFFFFFF, dwClientCode, 1 );
 	RETURNIFERROR( rc, "IDgnSSvcOutputEvent::PlayEvents" );
 
 	// Now we want to wait until the playback finishes or is aborted

--- a/NatlinkSource/DragonCode.h
+++ b/NatlinkSource/DragonCode.h
@@ -28,6 +28,7 @@ class CDragonCode
 	CDragonCode() {
 		m_hMsgWnd = NULL;
 		m_dwKey = 0;
+		m_dragonMajorVersion = 13;
 		m_pBeginCallback = NULL;
 		m_pChangeCallback = NULL;
 		m_pFirstGramObj = NULL;
@@ -188,6 +189,11 @@ class CDragonCode
 
 	// the key for unregistering our engine sink (a SAPI thing)
 	DWORD m_dwKey;
+
+	// Dragon major version (e.g. 13, 15, 16).  Detected at connect time
+	// via IDgnSREngineControl::GetVersion.  DNS 16 has different COM
+	// calling conventions for PlayString and PlayEvents.
+	DWORD m_dragonMajorVersion;
 
 	// the name of the log file (or en empty string if not known).  We
 	// assume that this will be less than the maximum path and file name

--- a/NatlinkSource/DragonCode.h
+++ b/NatlinkSource/DragonCode.h
@@ -28,7 +28,6 @@ class CDragonCode
 	CDragonCode() {
 		m_hMsgWnd = NULL;
 		m_dwKey = 0;
-		m_dragonMajorVersion = 13;
 		m_pBeginCallback = NULL;
 		m_pChangeCallback = NULL;
 		m_pFirstGramObj = NULL;
@@ -53,6 +52,7 @@ class CDragonCode
 		m_pMessageStack = NULL;
 		m_pIDgnSSvcOutputEventA=0;
 		m_pIDgnSSvcOutputEvent=0;
+		m_pIDgnSSvcOutputEventW=0;
 		m_pIDgnSSvcInterpreter=0;
 		m_pIDgnSSvcInterpreterA=0;
 
@@ -180,6 +180,7 @@ class CDragonCode
 	IDgnSREngineControlPtr m_pIDgnSREngineControl;
 	IDgnSSvcOutputEventPtr m_pIDgnSSvcOutputEvent;
 	IDgnSSvcOutputEventA * m_pIDgnSSvcOutputEventA;
+	IDgnSSvcOutputEventW * m_pIDgnSSvcOutputEventW;
 
 	IServiceProviderPtr m_pIServiceProvider;
 	IDgnExtModSupStringsPtr m_pIDgnExtModSupStrings;
@@ -190,10 +191,6 @@ class CDragonCode
 	// the key for unregistering our engine sink (a SAPI thing)
 	DWORD m_dwKey;
 
-	// Dragon major version (e.g. 13, 15, 16).  Detected at connect time
-	// via IDgnSREngineControl::GetVersion.  DNS 16 has different COM
-	// calling conventions for PlayString and PlayEvents.
-	DWORD m_dragonMajorVersion;
 
 	// the name of the log file (or en empty string if not known).  We
 	// assume that this will be less than the maximum path and file name


### PR DESCRIPTION
Fix playString/playEvents ESP corruption/hanging on DNS 16 by passing notify=1 in the extra vtable parameter DPI 16 added to PlayString and PlayEvents.

I would appreciate testing and we might need to adjust the version gating Dragon v14/15?